### PR TITLE
Propagate errors which occur in beforeSave and afterSave functions

### DIFF
--- a/src/form-object/form-object.ts
+++ b/src/form-object/form-object.ts
@@ -161,10 +161,14 @@ export class FormObject {
       this._save(validForm).subscribe((savedModel: FormModel) => {
         this._afterSave(savedModel, validForm).subscribe((model: FormModel) => {
           form$.next(model);
+        }, (error) => {
+          form$.error(error);
         });
       }, (error) => {
         form$.error(error);
       });
+    }, (error) => {
+      form$.error(error)
     });
 
     return form$;


### PR DESCRIPTION
This PR fixes uncaught errors when beforeSave or afterSave functions return an error to the observable.