### PR TITLE
ExtendedFormArray now checks order when calculating changes

### DIFF
--- a/src/extended-form-array/extended-form-array.ts
+++ b/src/extended-form-array/extended-form-array.ts
@@ -48,9 +48,15 @@ export class ExtendedFromArray extends FormArray {
     const initialIds = initialValue.map((item: any) => item ? item['id'] : null).filter((item: any) => item);
     const currentIds = currentValue.map((item: any) => item ? item['id'] : null).filter((item: any) => item);
 
-    const hasTheSameIds: boolean = initialIds.every((id: string) => contains(currentIds, id));
+    let hasTheSameIdsAndOrder = true;
+    for (let initialIdIndex = 0; initialIdIndex < initialIds.length; initialIdIndex++) {
+      if (initialIds[initialIdIndex] !== currentIds[initialIdIndex]) {
+        hasTheSameIdsAndOrder = false;
+        break;
+      }
+    }
 
-    return !hasTheSameIds;
+    return !hasTheSameIdsAndOrder;
   }
 
   public resetValue(value: any = this.initialValue): void {


### PR DESCRIPTION
This PR makes ExtendedFormArray check not only presence of same IDs but also their order.

Small note: `for` loop was used instead of `forEach` because of breaking (small optimisation).