### PR TITLE
Handle date comparison when calculating isChanged on FormControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### 9.0.0
 
+  * [BUGFIX] Fixed `FormControl.isChanged` for `Date` values
+
+### 9.0.0
+
   * [BREAKING CHANGE] Removed dependecy to external services (see [Migration guide](https://infinum.github.io/ngx-form-object/docs/migration-guide#saving-a-form))
   * Add FormStore.isSubmitted
 

--- a/projects/ngx-form-object/src/lib/extended-form-control/extended-form-control.ts
+++ b/projects/ngx-form-object/src/lib/extended-form-control/extended-form-control.ts
@@ -1,5 +1,6 @@
 import { AsyncValidatorFn, FormControl, ValidatorFn } from '@angular/forms';
 import { isNumber } from '../helpers/helpers';
+import { isDate } from '../helpers/is-date/is-date.helper';
 import { isObject } from '../helpers/is-object/is-object.helper';
 
 export class ExtendedFormControl extends FormControl {
@@ -12,7 +13,6 @@ export class ExtendedFormControl extends FormControl {
     private readonly isRelationship: boolean = false,
   ) {
     super(formState, validator, asyncValidator);
-
     this.initialValue = this.value;
   }
 
@@ -28,8 +28,10 @@ export class ExtendedFormControl extends FormControl {
 
     // Empty objects should be equal
     if (isObject(initialValue) && isObject(currentValue)) {
-      if (Object.keys(initialValue).length === 0 && Object.keys(currentValue).length === 0) {
-        return false;
+      if (!isDate(initialValue) && !isDate(currentValue)) {
+        if (Object.keys(initialValue).length === 0 && Object.keys(currentValue).length === 0) {
+          return false;
+        }
       }
     }
 

--- a/projects/ngx-form-object/src/lib/helpers/is-date/is-date.helper.ts
+++ b/projects/ngx-form-object/src/lib/helpers/is-date/is-date.helper.ts
@@ -1,0 +1,3 @@
+export function isDate(value: any): boolean {
+  return value instanceof Date;
+}


### PR DESCRIPTION
When calculating `isChanged` on an `ExtendedFormControl`, empty objects are handled as a special case. This was causing a bug where two `Date`s fell into that special case as well.

In order to not introduce breaking changes, `Date` types are handled as another special case, but in the future `isChanged` function should became more generic.