### PR TITLE
Fix extended form array table spacing

### DIFF
--- a/docusaurus/docs/extended-form-controls.md
+++ b/docusaurus/docs/extended-form-controls.md
@@ -27,7 +27,7 @@ All of the extended controls add functionality to either `FormGroup`, `FormContr
 | `get isChanged()` | `boolean` | Returns `true` if current value is not equal to initial value, `false` otherwise |
 | `get currentValue` | `Array<any>` | Returns the current value of the control |
 | `get initialValue()` | `Array<any>` | Returns the initial value of the control |
-| `set initialValue(value: Array<any>)` | Sets the initial value of the control |
+| `set initialValue(value: Array<any>)` || Sets the initial value of the control |
 | `get currentRawValue()` | `Array<any>` | Returns the current value of the array, regardless of the `disabled` status of its controls |
 | `resetValue(value?: any)` | `value: any` | Resets the underlying form control, marking it `pristine` and `untouched` and sets the current and initial value to the one provided. If no value argument is provided, sets those values to `control.currentValue` |
 | `clear(clearFlags?: boolean)` | | Removes all controls from the array. If `clearFlags` is `true` it also resets the array making it `pristine` and `untouched`|

--- a/docusaurus/docs/extended-form-controls.md
+++ b/docusaurus/docs/extended-form-controls.md
@@ -27,7 +27,7 @@ All of the extended controls add functionality to either `FormGroup`, `FormContr
 | `get isChanged()` | `boolean` | Returns `true` if current value is not equal to initial value, `false` otherwise |
 | `get currentValue` | `Array<any>` | Returns the current value of the control |
 | `get initialValue()` | `Array<any>` | Returns the initial value of the control |
-| `set initialValue(value: Array<any>)` || Sets the initial value of the control |
+| `set initialValue(value: Array<any>)` | | Sets the initial value of the control |
 | `get currentRawValue()` | `Array<any>` | Returns the current value of the array, regardless of the `disabled` status of its controls |
 | `resetValue(value?: any)` | `value: any` | Resets the underlying form control, marking it `pristine` and `untouched` and sets the current and initial value to the one provided. If no value argument is provided, sets those values to `control.currentValue` |
 | `clear(clearFlags?: boolean)` | | Removes all controls from the array. If `clearFlags` is `true` it also resets the array making it `pristine` and `untouched`|

--- a/docusaurus/versioned_docs/version-8.x.x/extended-form-controls.md
+++ b/docusaurus/versioned_docs/version-8.x.x/extended-form-controls.md
@@ -27,7 +27,7 @@ All of the extended controls add functionality to either `FormGroup`, `FormContr
 | `isChanged` | `boolean` | Returns `true` if current value is not equal to initial value, `false` otherwise |
 | `get currentValue` | `Array<any>` | Returns the current value of the control |
 | `get initialValue()` | `Array<any>` | Returns the initial value of the control |
-| `set initialValue(value: Array<any>)` | Sets the initial value of the control |
+| `set initialValue(value: Array<any>)` | | Sets the initial value of the control |
 | `get currentRawValue()` | `Array<any>` | Returns the current value of the array, regardless of the `disabled` status of its controls |
 | `resetValue(value?: any)` | `value: any` | Resets the underlying form control, marking it `pristine` and `untouched` and sets the current and initial value to the one provided. If no value argument is provided, sets those values to `control.currentValue` |
 | `clear(clearFlags?: boolean)` | | Removes all controls from the array. If `clearFlags` is `true` it also resets the array making it `pristine` and `untouched`|

--- a/docusaurus/versioned_docs/version-9.0.0/extended-form-controls.md
+++ b/docusaurus/versioned_docs/version-9.0.0/extended-form-controls.md
@@ -27,7 +27,7 @@ All of the extended controls add functionality to either `FormGroup`, `FormContr
 | `get isChanged()` | `boolean` | Returns `true` if current value is not equal to initial value, `false` otherwise |
 | `get currentValue` | `Array<any>` | Returns the current value of the control |
 | `get initialValue()` | `Array<any>` | Returns the initial value of the control |
-| `set initialValue(value: Array<any>)` | Sets the initial value of the control |
+| `set initialValue(value: Array<any>)` | | Sets the initial value of the control |
 | `get currentRawValue()` | `Array<any>` | Returns the current value of the array, regardless of the `disabled` status of its controls |
 | `resetValue(value?: any)` | `value: any` | Resets the underlying form control, marking it `pristine` and `untouched` and sets the current and initial value to the one provided. If no value argument is provided, sets those values to `control.currentValue` |
 | `clear(clearFlags?: boolean)` | | Removes all controls from the array. If `clearFlags` is `true` it also resets the array making it `pristine` and `untouched`|


### PR DESCRIPTION
I have moved "Sets the initial value of the control" from return type to description column.

<img width="931" alt="Screenshot 2022-01-21 at 14 14 36" src="https://user-images.githubusercontent.com/34454495/150533463-32e5cf55-df70-4746-9595-28c4a9d9ee92.png">
