### PR TITLE
Feature/extended validator fn

### DIFF
--- a/projects/ngx-form-object-sample-app/src/app/models/user.form-object.ts
+++ b/projects/ngx-form-object-sample-app/src/app/models/user.form-object.ts
@@ -1,11 +1,11 @@
 import { Injector } from '@angular/core';
-import { ValidatorFn, Validators } from '@angular/forms';
-import { FormObject, FormObjectOptions } from 'ngx-form-object';
+import { Validators } from '@angular/forms';
+import { ExtendedValidatorFn, FormObject, FormObjectOptions } from 'ngx-form-object';
 import { Observable, of } from 'rxjs';
 import { User } from './user.model';
 
 export class UserFormObject extends FormObject<User> {
-	public validators: Record<string, ValidatorFn | Array<ValidatorFn>> = {
+	public validators: Record<string, ExtendedValidatorFn | Array<ExtendedValidatorFn>> = {
 		name: [Validators.required],
 	};
 

--- a/projects/ngx-form-object/src/lib/extended-form-array/extended-form-array.ts
+++ b/projects/ngx-form-object/src/lib/extended-form-array/extended-form-array.ts
@@ -1,16 +1,20 @@
-import { AbstractControl, AbstractControlOptions, AsyncValidatorFn, FormArray, ValidatorFn } from '@angular/forms';
+import { AbstractControl, AbstractControlOptions, FormArray, FormGroup } from '@angular/forms';
 import { contains } from '../helpers/helpers';
 import { isFormStore } from '../helpers/is-form-store/is-form-store.helper';
 import { isObject } from '../helpers/is-object/is-object.helper';
 import { PropertyOptions } from '../interfaces/property-options.interface';
+import { ExtendedAsyncValidatorFn } from '../types/extended-async-validator-fn.type';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
+import { ExtendedFormControl } from './../extended-form-control/extended-form-control';
+import { FormStore } from './../form-store/form-store';
 
 function hasId<T extends any = any>(item: T): boolean {
-	return item && (item.id || item.id === null);
+	return item && (item['id'] || item['id'] === null);
 }
 
 function hasMaxOneNullableId<T extends any = any>(initialIds: Array<T>, currentIds: Array<T>): boolean {
-	const initialNullables = initialIds.filter((item) => item && item.id === null).length;
-	const currentNullables = currentIds.filter((item) => item && item.id === null).length;
+	const initialNullables = initialIds.filter((item) => item && item['id'] === null).length;
+	const currentNullables = currentIds.filter((item) => item && item['id'] === null).length;
 
 	return initialNullables < 2 && currentNullables < 2 && initialNullables === currentNullables;
 }
@@ -19,9 +23,9 @@ export class ExtendedFormArray extends FormArray {
 	private _initialValue: Array<any>;
 
 	constructor(
-		controls: Array<AbstractControl>,
-		validatorOrOpts?: ValidatorFn | Array<ValidatorFn> | AbstractControlOptions | null,
-		asyncValidator?: AsyncValidatorFn | Array<AsyncValidatorFn> | null,
+		controls: Array<AbstractControl | ExtendedFormControl | FormGroup | FormStore<unknown>>,
+		validatorOrOpts?: ExtendedValidatorFn | Array<ExtendedValidatorFn> | AbstractControlOptions | null,
+		asyncValidator?: ExtendedAsyncValidatorFn | Array<ExtendedAsyncValidatorFn> | null,
 		private readonly propertyOptions: PropertyOptions = {}
 	) {
 		super(controls, validatorOrOpts, asyncValidator);

--- a/projects/ngx-form-object/src/lib/extended-form-control/extended-form-control.ts
+++ b/projects/ngx-form-object/src/lib/extended-form-control/extended-form-control.ts
@@ -1,16 +1,18 @@
-import { AsyncValidatorFn, FormControl, ValidatorFn } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import { isNumber } from '../helpers/helpers';
 import { isDate } from '../helpers/is-date/is-date.helper';
 import { isObject } from '../helpers/is-object/is-object.helper';
 import { PropertyOptions } from '../interfaces/property-options.interface';
+import { ExtendedAsyncValidatorFn } from '../types/extended-async-validator-fn.type';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
 
 export class ExtendedFormControl extends FormControl {
 	private _initialValue: any;
 
 	constructor(
 		formState?: any,
-		validator?: ValidatorFn | Array<ValidatorFn>,
-		asyncValidator?: AsyncValidatorFn | Array<AsyncValidatorFn>,
+		validator?: ExtendedValidatorFn | Array<ExtendedValidatorFn>,
+		asyncValidator?: ExtendedAsyncValidatorFn | Array<ExtendedAsyncValidatorFn>,
 		private readonly isRelationship: boolean = false,
 		private readonly propertyOptions: PropertyOptions = {}
 	) {

--- a/projects/ngx-form-object/src/lib/form-object-builder/form-object-builder.ts
+++ b/projects/ngx-form-object/src/lib/form-object-builder/form-object-builder.ts
@@ -1,10 +1,11 @@
-import { AbstractControl, FormBuilder, ValidatorFn } from '@angular/forms';
+import { FormBuilder } from '@angular/forms';
 import { ExtendedFormArray } from '../extended-form-array/extended-form-array';
 import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
 import { FormObject } from '../form-object/form-object';
 import { FormStore } from '../form-store/form-store';
 import { capitalize } from '../helpers/helpers';
 import { PropertyOptions } from '../interfaces/property-options.interface';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
 
 export class FormObjectBuilder<T> {
 	public formBuilder: FormBuilder;
@@ -14,7 +15,7 @@ export class FormObjectBuilder<T> {
 	}
 
 	public create(formObject: FormObject<T>): FormStore<T> {
-		const formFields: Record<string, AbstractControl> = {};
+		const formFields: Record<string, ExtendedFormControl> = {};
 
 		Object.assign(formFields, this.createAttributeFormFields(formObject));
 		Object.assign(formFields, this.createHasManyFormFields(formObject));
@@ -33,11 +34,13 @@ export class FormObjectBuilder<T> {
 	}
 
 	private createAttributeFormFields(formObject: FormObject<T>): object {
-		const attributeFormFields: Record<string, AbstractControl> = {};
+		const attributeFormFields: Record<string, ExtendedFormControl> = {};
 
 		formObject.attributePropertiesKeys.forEach((attributeName: string) => {
 			const buildFunction = formObject[`build${capitalize(attributeName.toString())}`];
-			const validators: ValidatorFn | Array<ValidatorFn> = formObject.getValidators(attributeName.toString());
+			const validators: ExtendedValidatorFn | Array<ExtendedValidatorFn> = formObject.getValidators(
+				attributeName.toString()
+			);
 			const maskFunction: Function = formObject[`mask${capitalize(attributeName.toString())}`]; // tslint:disable-line: ban-types
 
 			const originalFieldValue: any = formObject.model[attributeName];
@@ -53,11 +56,13 @@ export class FormObjectBuilder<T> {
 	}
 
 	private createHasManyFormFields(formObject: FormObject<T>): object {
-		const hasManyFormFields: Record<string, AbstractControl> = {};
+		const hasManyFormFields: Record<string, ExtendedFormControl> = {};
 
 		formObject.hasManyPropertiesKeys.forEach((propertyName: string) => {
 			const buildFunction = formObject[`build${capitalize(propertyName.toString())}`];
-			const validators: ValidatorFn | Array<ValidatorFn> = formObject.getValidators(propertyName.toString());
+			const validators: ExtendedValidatorFn | Array<ExtendedValidatorFn> = formObject.getValidators(
+				propertyName.toString()
+			);
 			const hasManyModels = formObject.model[propertyName];
 			const propertyOptions: PropertyOptions = formObject.hasManyProperties.get(propertyName);
 			// Build function must return instance of ExtendedFormArray
@@ -75,7 +80,9 @@ export class FormObjectBuilder<T> {
 		formObject.belongsToPropertiesKeys.forEach((propertyName: string | symbol) => {
 			const buildFunction: Function = formObject[`build${capitalize(propertyName.toString())}`]; // tslint:disable-line: ban-types
 			const belongsToModel = formObject.model[propertyName] || null;
-			const validators: ValidatorFn | Array<ValidatorFn> = formObject.getValidators(propertyName.toString());
+			const validators: ExtendedValidatorFn | Array<ExtendedValidatorFn> = formObject.getValidators(
+				propertyName.toString()
+			);
 			const propertyOptions: PropertyOptions = formObject.belongsToProperties.get(propertyName);
 
 			if (buildFunction) {
@@ -109,7 +116,9 @@ export class FormObjectBuilder<T> {
 		relationshipModels: Array<any> = [],
 		propertyOptions: PropertyOptions
 	): ExtendedFormArray {
-		const validators: ValidatorFn | Array<ValidatorFn> = formObject.getValidators(relationshipName.toString());
+		const validators: ExtendedValidatorFn | Array<ExtendedValidatorFn> = formObject.getValidators(
+			relationshipName.toString()
+		);
 		const formGroups: Array<any> = [];
 
 		relationshipModels.forEach((relationshipModel) => {
@@ -125,7 +134,7 @@ export class FormObjectBuilder<T> {
 
 		const relationshipFormGroups: ExtendedFormArray = new ExtendedFormArray(
 			formGroups,
-			validators as ValidatorFn,
+			validators as ExtendedValidatorFn,
 			null,
 			propertyOptions
 		);

--- a/projects/ngx-form-object/src/lib/form-object/form-object.spec.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.spec.ts
@@ -1,4 +1,5 @@
-import { ValidatorFn, Validators } from '@angular/forms';
+import { Validators } from '@angular/forms';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
 import { FormObject } from './form-object';
 // tslint:disable: max-classes-per-file
 
@@ -8,10 +9,10 @@ class UserMock {
 	public city: string;
 }
 
-const customValidatorFn: ValidatorFn = () => null;
+const customValidatorFn: ExtendedValidatorFn = () => null;
 
 class UserMockFormObject extends FormObject<UserMock> {
-	public validators: Record<string, ValidatorFn | Array<ValidatorFn>> = {
+	public validators: Record<string, ExtendedValidatorFn | Array<ExtendedValidatorFn>> = {
 		name: [customValidatorFn, Validators.required],
 		city: customValidatorFn,
 	};

--- a/projects/ngx-form-object/src/lib/form-object/form-object.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.ts
@@ -1,4 +1,4 @@
-import { ValidatorFn, Validators } from '@angular/forms';
+import { Validators } from '@angular/forms';
 import { Observable, of as observableOf, ReplaySubject, throwError } from 'rxjs';
 import { catchError, flatMap, take } from 'rxjs/operators';
 import { MetadataProperty } from '../enums/metadata-property.enum';
@@ -8,6 +8,7 @@ import { capitalize } from '../helpers/helpers';
 import { FormGroupOptions } from '../interfaces/form-group-options.interface';
 import { FormObjectOptions } from '../interfaces/form-object-options.interface';
 import { PropertyOptions } from '../interfaces/property-options.interface';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
 import { ModelMetadata } from '../types/model-metadata.type';
 import { FormError } from './../interfaces/form-error.interface';
 
@@ -19,7 +20,7 @@ const defaultModelOptions: FormObjectOptions = {
 
 export abstract class FormObject<T> {
 	public _options: FormObjectOptions;
-	public validators: Record<string, ValidatorFn | Array<ValidatorFn>> = {};
+	public validators: Record<string, ExtendedValidatorFn | Array<ExtendedValidatorFn>> = {};
 	public formGroupOptions: FormGroupOptions = {};
 	public formStoreClass: new () => FormStore<T>;
 
@@ -82,11 +83,11 @@ export abstract class FormObject<T> {
 		return this._options.getModelType(model);
 	}
 
-	public getValidators(attributeName: string): ValidatorFn | Array<ValidatorFn> {
+	public getValidators(attributeName: string): ExtendedValidatorFn | Array<ExtendedValidatorFn> {
 		const validators = this.validators[attributeName];
 
 		if (validators && validators.length > 1) {
-			return Validators.compose(validators as Array<ValidatorFn>);
+			return Validators.compose(validators as Array<ExtendedValidatorFn>);
 		} else {
 			return validators;
 		}

--- a/projects/ngx-form-object/src/lib/interfaces/form-group-options.interface.ts
+++ b/projects/ngx-form-object/src/lib/interfaces/form-group-options.interface.ts
@@ -1,6 +1,7 @@
-import { AsyncValidatorFn, ValidatorFn } from '@angular/forms';
+import { ExtendedAsyncValidatorFn } from '../types/extended-async-validator-fn.type';
+import { ExtendedValidatorFn } from '../types/extended-validator-fn.type';
 
 export interface FormGroupOptions {
-	validator?: ValidatorFn;
-	asyncValidator?: AsyncValidatorFn;
+	validator?: ExtendedValidatorFn;
+	asyncValidator?: ExtendedAsyncValidatorFn;
 }

--- a/projects/ngx-form-object/src/lib/types/extended-async-validator-fn.type.ts
+++ b/projects/ngx-form-object/src/lib/types/extended-async-validator-fn.type.ts
@@ -1,0 +1,7 @@
+import { ValidationErrors } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
+
+export type ExtendedAsyncValidatorFn = (
+	extendedFormControl: ExtendedFormControl
+) => Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;

--- a/projects/ngx-form-object/src/lib/types/extended-validator-fn.type.ts
+++ b/projects/ngx-form-object/src/lib/types/extended-validator-fn.type.ts
@@ -1,0 +1,7 @@
+import { FormGroup, ValidationErrors } from '@angular/forms';
+import { ExtendedFormArray } from '../extended-form-array/extended-form-array';
+import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
+
+export type ExtendedValidatorFn = (
+	formProperty: ExtendedFormControl | ExtendedFormArray | FormGroup
+) => ValidationErrors | null;

--- a/projects/ngx-form-object/src/public-api.ts
+++ b/projects/ngx-form-object/src/public-api.ts
@@ -20,6 +20,8 @@ export * from './lib/decorators/attribute/attribute.decorator';
 export * from './lib/decorators/belongs-to/belongs-to.decorator';
 export * from './lib/decorators/has-many/has-many.decorator';
 
+export * from './lib/types/extended-async-validator-fn.type';
+export * from './lib/types/extended-validator-fn.type';
 export * from './lib/types/model-metadata.type';
 
 export * from './lib/enums/metadata-property.enum';


### PR DESCRIPTION
Added `ExtendedValidatorFn` so that validators can be typed with `Record<string, ExtendedValidatorFn | Array<ExtendedValidatorFn>>` instead of `object` or `any`.