### PR TITLE
Refactor storing model properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13934,7 +13934,8 @@
 		"reflect-metadata": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"@angular/platform-browser": "^8.2.14",
 		"@angular/platform-browser-dynamic": "^8.2.14",
 		"lint-staged": "^12.3.2",
-		"reflect-metadata": "^0.1.13",
 		"rxjs": "~6.4.0",
 		"tslib": "^1.10.0",
 		"tsutils": "^3.17.1",

--- a/projects/ngx-form-object/package.json
+++ b/projects/ngx-form-object/package.json
@@ -23,7 +23,6 @@
 		"@angular/common": ">=8",
 		"@angular/forms": ">=8",
 		"@angular/core": ">=8",
-		"rxjs": ">=6.4.0",
-		"reflect-metadata": ">=0.1.13"
+		"rxjs": ">=6.4.0"
 	}
 }

--- a/projects/ngx-form-object/src/lib/decorators/attribute/attribute.decorator.ts
+++ b/projects/ngx-form-object/src/lib/decorators/attribute/attribute.decorator.ts
@@ -1,14 +1,21 @@
-import { MetadataProperty } from '../../enums/metadata-property.enum';
 import { PropertyOptions } from '../../interfaces/property-options.interface';
-import { ModelMetadata } from '../../types/model-metadata.type';
+import { MODEL_ATTRIBUTE_PROPERTIES } from '../../types/model-metadata.type';
 
 export function Attribute(options: PropertyOptions = {}): PropertyDecorator {
 	return (target: Record<string, unknown>, propertyName: string | symbol) => {
-		const modelMetadata: ModelMetadata = Reflect.getMetadata(MetadataProperty.MODEL_METADATA, target.constructor) || {};
+		const modelAttributePropertiesDescriptor: PropertyDescriptor = Object.getOwnPropertyDescriptor(
+			target,
+			MODEL_ATTRIBUTE_PROPERTIES
+		) || { value: new Map() };
+		const attributeProperties: Map<string | symbol, PropertyOptions> = modelAttributePropertiesDescriptor.value;
 
-		modelMetadata.attributeProperties = modelMetadata.attributeProperties || new Map();
-		modelMetadata.attributeProperties.set(propertyName, options);
+		attributeProperties.set(propertyName, options);
 
-		Reflect.defineMetadata(MetadataProperty.MODEL_METADATA, modelMetadata, target.constructor);
+		Object.defineProperty(target, MODEL_ATTRIBUTE_PROPERTIES, {
+			enumerable: false,
+			writable: true,
+			configurable: false,
+			value: attributeProperties,
+		});
 	};
 }

--- a/projects/ngx-form-object/src/lib/decorators/belongs-to/belongs-to.decorator.ts
+++ b/projects/ngx-form-object/src/lib/decorators/belongs-to/belongs-to.decorator.ts
@@ -1,14 +1,21 @@
-import { MetadataProperty } from '../../enums/metadata-property.enum';
 import { PropertyOptions } from '../../interfaces/property-options.interface';
-import { ModelMetadata } from '../../types/model-metadata.type';
+import { MODEL_HAS_ONE_PROPERTIES } from '../../types/model-metadata.type';
 
 export function BelongsTo(options: PropertyOptions = {}): PropertyDecorator {
 	return (target: Record<string, unknown>, propertyName: string | symbol) => {
-		const modelMetadata: ModelMetadata = Reflect.getMetadata(MetadataProperty.MODEL_METADATA, target.constructor) || {};
+		const modelAttributePropertiesDescriptor: PropertyDescriptor = Object.getOwnPropertyDescriptor(
+			target,
+			MODEL_HAS_ONE_PROPERTIES
+		) || { value: new Map() };
+		const attributeProperties: Map<string | symbol, PropertyOptions> = modelAttributePropertiesDescriptor.value;
 
-		modelMetadata.belongsToProperties = modelMetadata.belongsToProperties || new Map();
-		modelMetadata.belongsToProperties.set(propertyName, options);
+		attributeProperties.set(propertyName, options);
 
-		Reflect.defineMetadata(MetadataProperty.MODEL_METADATA, modelMetadata, target.constructor);
+		Object.defineProperty(target, MODEL_HAS_ONE_PROPERTIES, {
+			enumerable: false,
+			writable: true,
+			configurable: false,
+			value: attributeProperties,
+		});
 	};
 }

--- a/projects/ngx-form-object/src/lib/decorators/has-many/has-many.decorator.ts
+++ b/projects/ngx-form-object/src/lib/decorators/has-many/has-many.decorator.ts
@@ -1,14 +1,21 @@
-import { MetadataProperty } from '../../enums/metadata-property.enum';
 import { PropertyOptions } from '../../interfaces/property-options.interface';
-import { ModelMetadata } from '../../types/model-metadata.type';
+import { MODEL_HAS_MANY_PROPERTIES } from '../../types/model-metadata.type';
 
 export function HasMany(options: PropertyOptions = {}): PropertyDecorator {
 	return (target: Record<string, unknown>, propertyName: string | symbol) => {
-		const modelMetadata: ModelMetadata = Reflect.getMetadata(MetadataProperty.MODEL_METADATA, target.constructor) || {};
+		const modelAttributePropertiesDescriptor: PropertyDescriptor = Object.getOwnPropertyDescriptor(
+			target,
+			MODEL_HAS_MANY_PROPERTIES
+		) || { value: new Map() };
+		const attributeProperties: Map<string | symbol, PropertyOptions> = modelAttributePropertiesDescriptor.value;
 
-		modelMetadata.hasManyProperties = modelMetadata.hasManyProperties || new Map();
-		modelMetadata.hasManyProperties.set(propertyName, options);
+		attributeProperties.set(propertyName, options);
 
-		Reflect.defineMetadata(MetadataProperty.MODEL_METADATA, modelMetadata, target.constructor);
+		Object.defineProperty(target, MODEL_HAS_MANY_PROPERTIES, {
+			enumerable: false,
+			writable: true,
+			configurable: false,
+			value: attributeProperties,
+		});
 	};
 }

--- a/projects/ngx-form-object/src/lib/enums/metadata-property.enum.ts
+++ b/projects/ngx-form-object/src/lib/enums/metadata-property.enum.ts
@@ -1,3 +1,0 @@
-export const enum MetadataProperty {
-	MODEL_METADATA = 'ModelMetadata',
-}

--- a/projects/ngx-form-object/src/lib/form-object/form-object.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.ts
@@ -1,7 +1,6 @@
 import { ValidatorFn, Validators } from '@angular/forms';
 import { Observable, of as observableOf, ReplaySubject, throwError } from 'rxjs';
 import { catchError, flatMap, take } from 'rxjs/operators';
-import { MetadataProperty } from '../enums/metadata-property.enum';
 import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
 import { FormStore } from '../form-store/form-store';
 import { getPropertiesFromPrototypeChain } from '../helpers/get-propertis-from-prototype-chain/get-properties-from-prototype-chain.helper';
@@ -9,7 +8,11 @@ import { capitalize } from '../helpers/helpers';
 import { FormGroupOptions } from '../interfaces/form-group-options.interface';
 import { FormObjectOptions } from '../interfaces/form-object-options.interface';
 import { PropertyOptions } from '../interfaces/property-options.interface';
-import { ModelMetadata, MODEL_ATTRIBUTE_PROPERTIES, MODEL_HAS_ONE_PROPERTIES } from '../types/model-metadata.type';
+import {
+	MODEL_ATTRIBUTE_PROPERTIES,
+	MODEL_HAS_MANY_PROPERTIES,
+	MODEL_HAS_ONE_PROPERTIES,
+} from '../types/model-metadata.type';
 import { FormError } from './../interfaces/form-error.interface';
 
 // TODO better default values
@@ -53,9 +56,7 @@ export abstract class FormObject {
 	}
 
 	public get hasManyProperties(): Map<string | symbol, PropertyOptions> {
-		const modelMetadata: ModelMetadata =
-			Reflect.getMetadata(MetadataProperty.MODEL_METADATA, this.model.constructor) || {};
-		return modelMetadata.hasManyProperties || new Map();
+		return getPropertiesFromPrototypeChain.call(this.model, MODEL_HAS_MANY_PROPERTIES);
 	}
 
 	public get hasManyPropertiesKeys(): Array<string | symbol> {

--- a/projects/ngx-form-object/src/lib/form-object/form-object.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.ts
@@ -9,7 +9,7 @@ import { capitalize } from '../helpers/helpers';
 import { FormGroupOptions } from '../interfaces/form-group-options.interface';
 import { FormObjectOptions } from '../interfaces/form-object-options.interface';
 import { PropertyOptions } from '../interfaces/property-options.interface';
-import { ModelMetadata, MODEL_ATTRIBUTE_PROPERTIES } from '../types/model-metadata.type';
+import { ModelMetadata, MODEL_ATTRIBUTE_PROPERTIES, MODEL_HAS_ONE_PROPERTIES } from '../types/model-metadata.type';
 import { FormError } from './../interfaces/form-error.interface';
 
 // TODO better default values
@@ -63,9 +63,7 @@ export abstract class FormObject {
 	}
 
 	public get belongsToProperties(): Map<string | symbol, PropertyOptions> {
-		const modelMetadata: ModelMetadata =
-			Reflect.getMetadata(MetadataProperty.MODEL_METADATA, this.model.constructor) || {};
-		return modelMetadata.belongsToProperties || new Map();
+		return getPropertiesFromPrototypeChain.call(this.model, MODEL_HAS_ONE_PROPERTIES);
 	}
 
 	public get belongsToPropertiesKeys(): Array<string | symbol> {

--- a/projects/ngx-form-object/src/lib/form-object/form-object.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.ts
@@ -4,11 +4,12 @@ import { catchError, flatMap, take } from 'rxjs/operators';
 import { MetadataProperty } from '../enums/metadata-property.enum';
 import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
 import { FormStore } from '../form-store/form-store';
+import { getPropertiesFromPrototypeChain } from '../helpers/get-propertis-from-prototype-chain/get-properties-from-prototype-chain.helper';
 import { capitalize } from '../helpers/helpers';
 import { FormGroupOptions } from '../interfaces/form-group-options.interface';
 import { FormObjectOptions } from '../interfaces/form-object-options.interface';
 import { PropertyOptions } from '../interfaces/property-options.interface';
-import { ModelMetadata } from '../types/model-metadata.type';
+import { ModelMetadata, MODEL_ATTRIBUTE_PROPERTIES } from '../types/model-metadata.type';
 import { FormError } from './../interfaces/form-error.interface';
 
 // TODO better default values
@@ -19,7 +20,7 @@ const defaultModelOptions: FormObjectOptions = {
 
 export abstract class FormObject {
 	public _options: FormObjectOptions;
-	public validators: Record<string, unknown> = {};
+	public validators: Record<string, unknown> | any = {};
 	public formGroupOptions: FormGroupOptions = {};
 	public formStoreClass: any;
 
@@ -44,9 +45,7 @@ export abstract class FormObject {
 	}
 
 	public get attributeProperties(): Map<string | symbol, PropertyOptions> {
-		const modelMetadata: ModelMetadata =
-			Reflect.getMetadata(MetadataProperty.MODEL_METADATA, this.model.constructor) || {};
-		return modelMetadata.attributeProperties || new Map();
+		return getPropertiesFromPrototypeChain.call(this.model, MODEL_ATTRIBUTE_PROPERTIES);
 	}
 
 	public get attributePropertiesKeys(): Array<string | symbol> {

--- a/projects/ngx-form-object/src/lib/helpers/get-propertis-from-prototype-chain/get-properties-from-prototype-chain.helper.ts
+++ b/projects/ngx-form-object/src/lib/helpers/get-propertis-from-prototype-chain/get-properties-from-prototype-chain.helper.ts
@@ -1,0 +1,18 @@
+import { PropertyOptions } from '../../interfaces/property-options.interface';
+
+export function getPropertiesFromPrototypeChain(
+	propertyName: string | symbol,
+	properties: Map<string | symbol, PropertyOptions> = new Map()
+): Map<string | symbol, PropertyOptions> {
+	let result: Map<string | symbol, PropertyOptions> = properties;
+
+	if (this[propertyName]) {
+		result = new Map([...properties, ...this[propertyName]]);
+	}
+
+	if (Object.getPrototypeOf(this)) {
+		return getPropertiesFromPrototypeChain.call(Object.getPrototypeOf(this), propertyName, result);
+	}
+
+	return result;
+}

--- a/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
+++ b/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
@@ -1,6 +1,7 @@
 import { PropertyOptions } from '../interfaces/property-options.interface';
 
 export const MODEL_ATTRIBUTE_PROPERTIES = Symbol('model_attribute_properties');
+export const MODEL_HAS_ONE_PROPERTIES = Symbol('model_has_one_properties');
 
 export interface ModelMetadata {
 	attributeProperties: Map<string | symbol, PropertyOptions>;

--- a/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
+++ b/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
@@ -1,10 +1,3 @@
-import { PropertyOptions } from '../interfaces/property-options.interface';
-
 export const MODEL_ATTRIBUTE_PROPERTIES = Symbol('model_attribute_properties');
 export const MODEL_HAS_ONE_PROPERTIES = Symbol('model_has_one_properties');
-
-export interface ModelMetadata {
-	attributeProperties: Map<string | symbol, PropertyOptions>;
-	belongsToProperties: Map<string | symbol, PropertyOptions>;
-	hasManyProperties: Map<string | symbol, PropertyOptions>;
-}
+export const MODEL_HAS_MANY_PROPERTIES = Symbol('model_has_many_properties');

--- a/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
+++ b/projects/ngx-form-object/src/lib/types/model-metadata.type.ts
@@ -1,5 +1,7 @@
 import { PropertyOptions } from '../interfaces/property-options.interface';
 
+export const MODEL_ATTRIBUTE_PROPERTIES = Symbol('model_attribute_properties');
+
 export interface ModelMetadata {
 	attributeProperties: Map<string | symbol, PropertyOptions>;
 	belongsToProperties: Map<string | symbol, PropertyOptions>;

--- a/projects/ngx-form-object/src/public-api.ts
+++ b/projects/ngx-form-object/src/public-api.ts
@@ -22,8 +22,6 @@ export * from './lib/decorators/has-many/has-many.decorator';
 
 export * from './lib/types/model-metadata.type';
 
-export * from './lib/enums/metadata-property.enum';
-
 @NgModule({
 	imports: [CommonModule, ReactiveFormsModule],
 	providers: [FormObjectBuilder],

--- a/projects/ngx-form-object/src/public-api.ts
+++ b/projects/ngx-form-object/src/public-api.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata';
-
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';

--- a/projects/ngx-form-object/src/test.ts
+++ b/projects/ngx-form-object/src/test.ts
@@ -2,7 +2,6 @@
 
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
-import 'reflect-metadata';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 


### PR DESCRIPTION
- removed usage of `reflect-metadata`
- fixed the issue with sharing properties via parent class