### PR TITLE
Create form automatically

### DIFF
--- a/docusaurus/docs/api-reference/decorators.md
+++ b/docusaurus/docs/api-reference/decorators.md
@@ -7,7 +7,7 @@ sidebar_label: Decorators
 ## Model decorators
 
 `ngx-form-object` exposes three model decorators: `Attribute()`, `BelongsTo()`, and `HasMany()`.
-You can use one of these decorators to specify what kind of form controls should `FormObjectbuilder` create for different model properties.
+These decorators are used for specifying what kind of form controls should be created for different model properties.
 
 ### @Attribute()
 

--- a/docusaurus/docs/api-reference/form-object.md
+++ b/docusaurus/docs/api-reference/form-object.md
@@ -14,6 +14,13 @@ constructor(model: T, options: FormObjectOptions);
 
 ## Properties
 
+### get form
+
+| Property | Return type |
+| --------- | ------------- |
+| `get form` | <code>FormStore</code> |
+
+
 ### attributeProperties
 
 | Property | Return type |

--- a/docusaurus/docs/api-reference/form-object.md
+++ b/docusaurus/docs/api-reference/form-object.md
@@ -18,7 +18,7 @@ constructor(model: T, options: FormObjectOptions);
 
 | Property | Return type |
 | --------- | ------------- |
-| `get form` | <code>FormStore</code> |
+| `get form` | `FormStore` |
 
 
 ### attributeProperties

--- a/docusaurus/docs/getting-started/basic-usage.md
+++ b/docusaurus/docs/getting-started/basic-usage.md
@@ -44,14 +44,13 @@ export class UserFormObject extends FormObject<User> {
 ```
 
 ## 3. Create a form store (form)
-`FormObject` is created out of the model. To create a `FormStore` out of that `FormObject`, inject or instatiate a `FormObjectBuilder` in your component/service.
-Use `FormObjectBuilder.create` to create the `FormStore`.
+`FormObject` is created out of the model. Once created, the actual form can be accessed via `formObject.form` getter.
 
 ```ts
 const user: User = new User();
 const userFormObject: UserFormObject = new UserFormObject(user, null);
-const formObjectBuilder: FormObjectBuidler = new FormObjectBuilder();
-const userForm: FormStore<User> = this.formObjectBuilder.create(userFormObject);
+
+const userForm: FormStore<User> = userFormObject.form;
 ```
 
 ## 4. Map form store to the template

--- a/docusaurus/docs/guides/defining-relationship-form-fields.md
+++ b/docusaurus/docs/guides/defining-relationship-form-fields.md
@@ -4,7 +4,7 @@ title: Defining relationship form fields
 sidebar_label: Defining relationship form fields
 ---
 
-`FormObjectBuilder` has a default behaviour for every type of form field relationship:
+When creating a form, there is a default behaviour for every type of form field relationship:
 
 * `Attribute` form field - `ExtendedFormControl` will be created
 * `BelongsTo` form field - `ExtendedFormControl` will be created

--- a/projects/ngx-form-object-sample-app/src/app/app.component.ts
+++ b/projects/ngx-form-object-sample-app/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, Injector } from '@angular/core';
-import { FormObjectBuilder, FormStore } from 'ngx-form-object';
+import { FormStore } from 'ngx-form-object';
 import { UserFormObject } from './models/user.form-object';
 import { User } from './models/user.model';
 
@@ -11,11 +11,11 @@ import { User } from './models/user.model';
 export class AppComponent {
 	public userFormStore: FormStore;
 
-	constructor(private readonly formObjectBuilder: FormObjectBuilder, public injector: Injector) {
+	constructor(public injector: Injector) {
 		const user: User = new User();
 		user.name = 'Steve';
 		const userFormObject = new UserFormObject(user, null, this.injector);
-		this.userFormStore = this.formObjectBuilder.create(userFormObject);
+		this.userFormStore = userFormObject.form;
 	}
 
 	public onSubmit(): void {

--- a/projects/ngx-form-object/src/lib/form-object-builder/form-object-builder.ts
+++ b/projects/ngx-form-object/src/lib/form-object-builder/form-object-builder.ts
@@ -7,11 +7,7 @@ import { capitalize } from '../helpers/helpers';
 import { PropertyOptions } from '../interfaces/property-options.interface';
 
 export class FormObjectBuilder {
-	public formBuilder: FormBuilder;
-
-	constructor() {
-		this.formBuilder = new FormBuilder();
-	}
+	public formBuilder: FormBuilder = new FormBuilder();
 
 	public create(formObject: FormObject): FormStore {
 		const formFields = {};

--- a/projects/ngx-form-object/src/lib/form-object/form-object.ts
+++ b/projects/ngx-form-object/src/lib/form-object/form-object.ts
@@ -2,6 +2,7 @@ import { ValidatorFn, Validators } from '@angular/forms';
 import { Observable, of as observableOf, throwError } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { ExtendedFormControl } from '../extended-form-control/extended-form-control';
+import { FormObjectBuilder } from '../form-object-builder/form-object-builder';
 import { FormStore } from '../form-store/form-store';
 import { getPropertiesFromPrototypeChain } from '../helpers/get-propertis-from-prototype-chain/get-properties-from-prototype-chain.helper';
 import { capitalize } from '../helpers/helpers';
@@ -13,6 +14,8 @@ import {
 	MODEL_HAS_MANY_PROPERTIES,
 	MODEL_HAS_ONE_PROPERTIES,
 } from '../types/model-metadata.type';
+
+const formPropertyKey = Symbol('form');
 
 // TODO better default values
 const defaultModelOptions: FormObjectOptions = {
@@ -44,6 +47,14 @@ export abstract class FormObject {
 			...defaultModelOptions,
 			...options,
 		};
+	}
+
+	public get form(): FormStore {
+		if (!this[formPropertyKey]) {
+			return this.initializeForm();
+		}
+
+		return this[formPropertyKey];
 	}
 
 	public get attributeProperties(): Map<string | symbol, PropertyOptions> {
@@ -223,5 +234,16 @@ export abstract class FormObject {
 				formControl.resetValue();
 			}
 		});
+	}
+
+	private createForm(): FormStore {
+		const formBuilder: FormObjectBuilder = new FormObjectBuilder();
+		return formBuilder.create(this);
+	}
+
+	public initializeForm(): FormStore {
+		const form: FormStore = this.createForm();
+		this[formPropertyKey] = form;
+		return form;
 	}
 }


### PR DESCRIPTION
When creating a form object, underlying form is created automatically. Because of that `FormObjectBuilder` doesn't have to be exposed anymore.
At the moment, `FormObjectBuilder` is still exposed to avoid breaking changes, however, it should not be exposed in future releases.