### PR TITLE
Fix publish script for Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
 		"copy-license": "cp ./LICENSE ./dist/ngx-form-object",
 		"copy-readme": "cp ./README.md ./dist/ngx-form-object",
 		"copy-files": "npm run copy-license && npm run copy-readme",
-		"publish": "npm run test && npm run build && npm publish dist/ngx-form-object",
-		"publish-beta": "npm run test && npm run build && npm publish dist/ngx-form-object --tag beta"
+		"publish": "npm run test && npm run build && npm publish dist/ngx-form-object/",
+		"publish-beta": "npm run test && npm run build && npm publish dist/ngx-form-object/ --tag beta"
 	},
 	"dependencies": {
 		"@angular/common": "^12.2.16",


### PR DESCRIPTION
This PR updates the paths of `publish` and `publish-beta` scripts. This is a bug in NPM which should be fixed in future versions. Issue and fix is documented here: https://github.com/npm/cli/issues/3993.